### PR TITLE
Improve tutorial with probability notation explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This web app visualizes **Bayes' theorem** through a set of sliders and an SVG diagram. The application allows you to manipulate the prior probability of a hypothesis and the likelihood of evidence in both the true and false cases. As you adjust the sliders the graphic and the computed posterior probability update instantly. The goal is to help students build intuition for how beliefs are updated when new evidence appears.
 
+The notation in the app follows standard probability conventions. For example,
+`P(E | H)` is read as "the probability of the evidence `E` assuming the
+hypothesis `H` is true." Likewise, `P(E | ¬H)` represents the probability of the
+evidence when the hypothesis does not hold&mdash;the symbol `¬` simply means
+"not." These quantities feed into Bayes' theorem to compute the updated belief
+`P(H | E)`.
+
 ## Quick start
 
 Clone repository, open `bayes_interactive.html` in your browser.

--- a/bayes_interactive.html
+++ b/bayes_interactive.html
@@ -7,9 +7,15 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="sidebar">
-    <h1>Bayes' Theorem</h1>
-    <p>This interactive tool helps you explore Bayes' theorem by adjusting the parameters below. The formula expresses how to update a belief (hypothesis H) in light of new evidence (E). The three sliders correspond to the prior probability of the hypothesis, the likelihood of seeing the evidence when the hypothesis is true, and the likelihood of seeing the evidence when the hypothesis is false.</p>
+    <div class="sidebar">
+      <h1>Bayes' Theorem</h1>
+      <p>This interactive tool helps you explore Bayes' theorem by adjusting the parameters below. The formula expresses how to update a belief (hypothesis H) in light of new evidence (E). The three sliders correspond to the prior probability of the hypothesis, the likelihood of seeing the evidence when the hypothesis is true, and the likelihood of seeing the evidence when the hypothesis is false.</p>
+      <p>
+        In the notation <em>P(E | H)</em>, the bar "|" means "given that." It represents the
+        probability of observing the evidence if the hypothesis is true. Likewise,
+        <em>P(E | ¬H)</em> denotes the probability of seeing the evidence assuming the
+        hypothesis is false; the symbol "¬" simply means "not".
+      </p>
     <div class="slider-group">
       <label for="pA">Prior probability P(H)</label>
       <input type="range" id="pA" min="0" max="1" step="0.01" value="0.5" />


### PR DESCRIPTION
## Summary
- add a brief explanation of probability notation to `bayes_interactive.html`
- expand README with clarification of notation

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882f03da1c88329abdd586d54c63198