### PR TITLE
Add labels for prior and likelihood around diagram

### DIFF
--- a/bayes_interactive.html
+++ b/bayes_interactive.html
@@ -41,7 +41,12 @@
     </div>
   </div>
   <div class="content">
-    <svg id="plot" width="400" height="400"></svg>
+    <div id="plot-container">
+      <svg id="plot" width="400" height="400"></svg>
+      <div class="diagram-label prior-label">Prior</div>
+      <div class="diagram-label likelihood-label">Likelihood</div>
+      <div class="diagram-label alt-likelihood-label">Alternative Liklihood</div>
+    </div>
   </div>
   <script src="main.js"></script>
 

--- a/style.css
+++ b/style.css
@@ -51,6 +51,32 @@ body {
       background-color: #fafafa;
     }
 
+    .diagram-label {
+      position: absolute;
+      font-weight: bold;
+      background-color: rgba(255, 255, 255, 0.8);
+      padding: 2px 4px;
+      pointer-events: none;
+    }
+
+    .prior-label {
+      bottom: -25px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .likelihood-label {
+      top: 50%;
+      left: -10px;
+      transform: translate(-100%, -50%);
+    }
+
+    .alt-likelihood-label {
+      top: 50%;
+      right: -10px;
+      transform: translate(100%, -50%);
+    }
+
     /* Colors for the rectangles */
     .rect-AB {
       fill: #4a90d9; /* medium blue */


### PR DESCRIPTION
## Summary
- add container around the SVG diagram
- insert outside labels for Prior, Likelihood, and Alternative Liklihood
- style new labels for placement beside the diagram

## Testing
- `node -e "require('./main.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6882f985e7408329a1a3a024eacf3cce