### PR TITLE
feat: Add visual box and back button

### DIFF
--- a/bayes_interactive.html
+++ b/bayes_interactive.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <div class="sidebar">
+      <a href="index.html" class="back-button">&larr; Back to Home</a>
       <h1>Bayes' Theorem</h1>
       <p>This interactive tool helps you explore Bayes' theorem by adjusting the parameters below. The formula expresses how to update a belief (hypothesis H) in light of new evidence (E). The three sliders correspond to the prior probability of the hypothesis, the likelihood of seeing the evidence when the hypothesis is true, and the likelihood of seeing the evidence when the hypothesis is false.</p>
       <p>

--- a/style.css
+++ b/style.css
@@ -24,6 +24,18 @@ body {
       padding: 20px;
     }
 
+    .back-button {
+      display: inline-block;
+      margin-bottom: 20px;
+      color: #4a90d9;
+      text-decoration: none;
+      font-weight: bold;
+    }
+
+    .back-button:hover {
+      text-decoration: underline;
+    }
+
     h1 {
       margin-top: 0;
     }
@@ -97,6 +109,10 @@ body {
     .posterior-display {
       font-size: 1.2em;
       margin-top: 10px;
+      padding: 10px;
+      border: 1px solid #ccc;
+      background-color: #f9f9f9;
+      border-radius: 5px;
     }
     .footer {
       margin-top: auto;


### PR DESCRIPTION
This commit adds a visual box around the posterior probability display to make it stand out. It also adds a back button to the page that links to the homepage.