### PR TITLE
feat: Add image and copyright notice

### DIFF
--- a/bayes_interactive.html
+++ b/bayes_interactive.html
@@ -51,6 +51,12 @@
       <div class="diagram-label likelihood-label">Likelihood</div>
       <div class="diagram-label alt-likelihood-label">Alternative Liklihood</div>
     </div>
+    <div class="image-container">
+      <img src="Bayes Theorem Formula v2.jpg" alt="Bayes Theorem Formula" class="bayes-formula">
+    </div>
+    <div class="copyright">
+      &copy;2025, Todd Brous
+    </div>
   </div>
   <script src="main.js"></script>
 

--- a/style.css
+++ b/style.css
@@ -122,3 +122,20 @@ body {
       font-size: 0.9em;
       color: #888;
     }
+
+    .image-container {
+      margin-top: 20px;
+    }
+
+    .bayes-formula {
+      width: 100%;
+      max-width: 400px;
+    }
+
+    .copyright {
+      position: fixed;
+      bottom: 10px;
+      right: 10px;
+      font-size: 0.8em;
+      color: #888;
+    }


### PR DESCRIPTION
This commit adds the Bayes Theorem formula image to the right-hand side of the page and a copyright notice to the lower right.